### PR TITLE
WID-181 Only add default settings to a widget in case there are no settings yet

### DIFF
--- a/src/app/core/widget/services/widget-type-registry.service.ts
+++ b/src/app/core/widget/services/widget-type-registry.service.ts
@@ -57,13 +57,16 @@ export class WidgetTypeRegistry {
 
       if (this.widgetTypes.hasOwnProperty(type)) {
         // Return an instance of the requested Widget type with default settings if no settings are provided
-        const defaultSettings = this.widgetTypes[type].defaultSettings;
-
+        const settings = values.hasOwnProperty('settings') ? _.get(values, 'settings') : deepmerge.all([
+            this.widgetTypes[type].defaultSettings, 
+            _.get(values, 'settings', {})
+        ], {clone: true});
+        
         return new this.widgetTypes[type].widget({
           id: _.get(values, 'id'),
           name: _.get(values, 'name'),
           type: type,
-          settings: deepmerge.all([defaultSettings, _.get(values, 'settings', {})], {clone: true})
+          settings: settings,
         });
       }
     }


### PR DESCRIPTION
### Fixed

- Fixed an issue that prevented removing groups from the accessibility section of a search-form widget.

---

The problem was that the default settings would always be merged when the widget was retrieved from the API. This was most noticeable when you removed a group and then refreshed the page. To fix it I changed it so the default settings are only applied when a new widget is created.