### PR TITLE
WID-466 - Add UiT in Vlaanderen, Vlieg and NXTPOP as publisher

### DIFF
--- a/src/app/widget-builder/components/widgets/search-results-widget/search-results-widget-edit.component.html
+++ b/src/app/widget-builder/components/widgets/search-results-widget/search-results-widget-edit.component.html
@@ -143,7 +143,9 @@
                         <div *ngIf="settings.items.editorial_label.limit_publishers" class="ml-4">
                             <div class="publisher-option" *ngFor="let publisher of publishersArray('items', 'editorial_label').controls;let i=index">
                               <input id="publisher{{i}}" type="checkbox" [formControl]="publisher" (change)="updateSelectedPublishers('items', 'editorial_label')">
-                              <label for="publisher{{i}}">{{ publishers[i] }}</label>
+                              <label for="publisher{{i}}">{{
+                                getPublisherLabel(publishers[i])
+                              }}</label>
                             </div>
                         </div>
                     </div>

--- a/src/app/widget-builder/components/widgets/search-results-widget/search-results-widget-edit.component.ts
+++ b/src/app/widget-builder/components/widgets/search-results-widget/search-results-widget-edit.component.ts
@@ -51,7 +51,16 @@ export class SearchResultsWidgetEditComponent extends BaseWidgetEditComponent {
     super(formBuilder, widgetBuilderService, queryStringService);
   }
 
-
+  public getPublisherLabel(publisher: string): string {
+    switch (publisher.toLowerCase()) {
+      case "uit":
+        return "UiTinVlaanderen";
+      case "uitmetvlieg":
+        return "Vlieg";
+      default:
+        return publisher;
+    }
+  }
 
   /**
    * @inheritDoc

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -3,14 +3,11 @@
  */
 export const environment = {
   production: false,
-  apiUrl: "https://projectaanvraag-api.uitdatabank.dev/",
+  apiUrl: 'https://projectaanvraag-api.uitdatabank.dev/',
   widgetApi_currentVersion: 3,
-  widgetApi_embedUrl_current:
-    "https://projectaanvraag-api.uitdatabank.dev/widgets/layout/:page_id.js",
-  widgetApi_embedUrl_forceCurrent:
-    "https://projectaanvraag-api.uitdatabank.dev/widgets/layout/v3/:page_id.js",
-  projectaanvraagDashboardUrl: "https://projectaanvraag.uitdatabank.dev/",
-  zendeskUrl: "http://www.zendesk.com",
-  publishers:
-    "BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX,UiT,UiTMetVlieg,NXTPOP",
+  widgetApi_embedUrl_current: 'https://projectaanvraag-api.uitdatabank.dev/widgets/layout/:page_id.js',
+  widgetApi_embedUrl_forceCurrent: 'https://projectaanvraag-api.uitdatabank.dev/widgets/layout/v3/:page_id.js',
+  projectaanvraagDashboardUrl: 'https://projectaanvraag.uitdatabank.dev/',
+  zendeskUrl: 'http://www.zendesk.com',
+  publishers: 'BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX,UiT,UiTMetVlieg,NXTPOP'
 };

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -3,11 +3,14 @@
  */
 export const environment = {
   production: false,
-  apiUrl: 'https://projectaanvraag-api.uitdatabank.dev/',
+  apiUrl: "https://projectaanvraag-api.uitdatabank.dev/",
   widgetApi_currentVersion: 3,
-  widgetApi_embedUrl_current: 'https://projectaanvraag-api.uitdatabank.dev/widgets/layout/:page_id.js',
-  widgetApi_embedUrl_forceCurrent: 'https://projectaanvraag-api.uitdatabank.dev/widgets/layout/v3/:page_id.js',
-  projectaanvraagDashboardUrl: 'https://projectaanvraag.uitdatabank.dev/',
-  zendeskUrl: 'http://www.zendesk.com',
-  publishers: 'BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX'
+  widgetApi_embedUrl_current:
+    "https://projectaanvraag-api.uitdatabank.dev/widgets/layout/:page_id.js",
+  widgetApi_embedUrl_forceCurrent:
+    "https://projectaanvraag-api.uitdatabank.dev/widgets/layout/v3/:page_id.js",
+  projectaanvraagDashboardUrl: "https://projectaanvraag.uitdatabank.dev/",
+  zendeskUrl: "http://www.zendesk.com",
+  publishers:
+    "BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX,UiT,UiTMetVlieg,NXTPOP",
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,10 +1,13 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://projectaanvraag-api-test.uitdatabank.be/',
+  apiUrl: "https://projectaanvraag-api-test.uitdatabank.be/",
   widgetApi_currentVersion: 3,
-  widgetApi_embedUrl_current: 'http://projectaanvraag-api-test.uitdatabank.be/widgets/layout/:page_id.js',
-  widgetApi_embedUrl_forceCurrent: 'http://projectaanvraag-api-test.uitdatabank.be/widgets/layout/v3/:page_id.js',
-  projectaanvraagDashboardUrl: 'https://projectaanvraag-test.uitdatabank.be/',
-  zendeskUrl: 'http://www.zendesk.com',
-  publishers: 'BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX'
+  widgetApi_embedUrl_current:
+    "http://projectaanvraag-api-test.uitdatabank.be/widgets/layout/:page_id.js",
+  widgetApi_embedUrl_forceCurrent:
+    "http://projectaanvraag-api-test.uitdatabank.be/widgets/layout/v3/:page_id.js",
+  projectaanvraagDashboardUrl: "https://projectaanvraag-test.uitdatabank.be/",
+  zendeskUrl: "http://www.zendesk.com",
+  publishers:
+    "BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX,UiT,UiTMetVlieg,NXTPOP",
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,13 +1,10 @@
 export const environment = {
   production: true,
-  apiUrl: "https://projectaanvraag-api-test.uitdatabank.be/",
+  apiUrl: 'https://projectaanvraag-api-test.uitdatabank.be/',
   widgetApi_currentVersion: 3,
-  widgetApi_embedUrl_current:
-    "http://projectaanvraag-api-test.uitdatabank.be/widgets/layout/:page_id.js",
-  widgetApi_embedUrl_forceCurrent:
-    "http://projectaanvraag-api-test.uitdatabank.be/widgets/layout/v3/:page_id.js",
-  projectaanvraagDashboardUrl: "https://projectaanvraag-test.uitdatabank.be/",
-  zendeskUrl: "http://www.zendesk.com",
-  publishers:
-    "BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX,UiT,UiTMetVlieg,NXTPOP",
+  widgetApi_embedUrl_current: 'http://projectaanvraag-api-test.uitdatabank.be/widgets/layout/:page_id.js',
+  widgetApi_embedUrl_forceCurrent: 'http://projectaanvraag-api-test.uitdatabank.be/widgets/layout/v3/:page_id.js',
+  projectaanvraagDashboardUrl: 'https://projectaanvraag-test.uitdatabank.be/',
+  zendeskUrl: 'http://www.zendesk.com',
+  publishers: 'BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX,UiT,UiTMetVlieg,NXTPOP'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,11 +5,14 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'https://projectaanvraag-api.uitdatabank.dev/',
+  apiUrl: "https://projectaanvraag-api.uitdatabank.dev/",
   widgetApi_currentVersion: 3,
-  widgetApi_embedUrl_current: 'http://projectaanvraag-api.uitdatabank.dev/widgets/layout/:page_id.js',
-  widgetApi_embedUrl_forceCurrent: 'https://projectaanvraag-api.uitdatabank.dev/widgets/layout/v3/:page_id.js',
-  projectaanvraagDashboardUrl: 'https://projectaanvraag.uitdatabank.dev/',
-  zendeskUrl: 'http://www.zendesk.com',
-  publishers: 'BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX'
+  widgetApi_embedUrl_current:
+    "http://projectaanvraag-api.uitdatabank.dev/widgets/layout/:page_id.js",
+  widgetApi_embedUrl_forceCurrent:
+    "https://projectaanvraag-api.uitdatabank.dev/widgets/layout/v3/:page_id.js",
+  projectaanvraagDashboardUrl: "https://projectaanvraag.uitdatabank.dev/",
+  zendeskUrl: "http://www.zendesk.com",
+  publishers:
+    "BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX,UiT,UiTMetVlieg,NXTPOP",
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,14 +5,11 @@
 
 export const environment = {
   production: false,
-  apiUrl: "https://projectaanvraag-api.uitdatabank.dev/",
+  apiUrl: 'https://projectaanvraag-api.uitdatabank.dev/',
   widgetApi_currentVersion: 3,
-  widgetApi_embedUrl_current:
-    "http://projectaanvraag-api.uitdatabank.dev/widgets/layout/:page_id.js",
-  widgetApi_embedUrl_forceCurrent:
-    "https://projectaanvraag-api.uitdatabank.dev/widgets/layout/v3/:page_id.js",
-  projectaanvraagDashboardUrl: "https://projectaanvraag.uitdatabank.dev/",
-  zendeskUrl: "http://www.zendesk.com",
-  publishers:
-    "BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX,UiT,UiTMetVlieg,NXTPOP",
+  widgetApi_embedUrl_current: 'http://projectaanvraag-api.uitdatabank.dev/widgets/layout/:page_id.js',
+  widgetApi_embedUrl_forceCurrent: 'https://projectaanvraag-api.uitdatabank.dev/widgets/layout/v3/:page_id.js',
+  projectaanvraagDashboardUrl: 'https://projectaanvraag.uitdatabank.dev/',
+  zendeskUrl: 'http://www.zendesk.com',
+  publishers: 'BRUZZ,Gazet van Antwerpen,Indiestyle,UiTX,UiT,UiTMetVlieg,NXTPOP'
 };


### PR DESCRIPTION
### Added
- UiT in Vlaanderen, Vlieg and NXTPOP as publishers
- Method to translate publisher label in UI


<img width="421" alt="Screenshot 2021-12-21 at 13 02 35" src="https://user-images.githubusercontent.com/9402377/146928207-f0b6e787-1326-4b6c-a1b9-b6ff1ff54bb8.png">

---
Ticket: https://jira.uitdatabank.be/browse/WID-446
