### PR TITLE
WID-325 - Remove deprecated buildOptimizer option

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -42,7 +42,6 @@
               "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
-              "buildOptimizer": true,
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",
@@ -64,7 +63,6 @@
               "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
-              "buildOptimizer": true,
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",


### PR DESCRIPTION
### Removed
- buildOptimizer flag (@angular-devkit/build-optimizer was used and is now deprecated)

### Fixed

- failing build after upgrade to Angular v11

---

Ticket: https://jira.uitdatabank.be/browse/WID-325
